### PR TITLE
Add example for RPC call to get current market info

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "forge:playground": "script/playground.sh"
   },
   "dependencies": {
-    "@compound-finance/comet-extension": "^0.0.5",
+    "@compound-finance/comet-extension": "^0.0.15",
     "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
     "@ethersproject/abi": "^5.6.2",
     "@ethersproject/bignumber": "^5.4.2",

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -64,6 +64,7 @@ export function App<N extends Network>({rpc, web3, account, networkConfig}: AppP
     extEnabled: false,
   });
   const [accountState, setAccountState] = useState<AccountState<Network>>(initialAccountState);
+  const [selectedMarketBaseAsset, setSelectedMarketBaseAsset] = useState<string>('N/A');
 
   const ext = useMemo(() => new Contract(networkConfig.extAddress, networkConfig.extAbi, signer), [signer]);
   const comet = useMemo(() => new Contract(networkConfig.rootsV3.comet, Comet, signer), [signer]);
@@ -79,6 +80,19 @@ export function App<N extends Network>({rpc, web3, account, networkConfig}: AppP
     await comet.allow(ext.address, false);
     console.log("disabling ext");
   }
+
+  useEffect(() => {
+    if (rpc) {
+      rpc.on({
+        setSelectedMarket: ({ selectedMarket }) => {
+          setSelectedMarketBaseAsset(selectedMarket.baseAssetSymbol);
+        }
+      });
+      rpc.sendRPC({ type: 'getSelectedMarket' }).then((data) =>
+        data.type === 'setSelectedMarket' && setSelectedMarketBaseAsset(data.selectedMarket.baseAssetSymbol)
+      );
+    }
+  }, [rpc]);
 
   return (
     <div className="page home">
@@ -108,6 +122,7 @@ export function App<N extends Network>({rpc, web3, account, networkConfig}: AppP
                 <label className="L1 label text-color--2">Debug Information</label>
                 <label className="label text-color--2">
                   network={ showNetwork(networkConfig.network) }<br/>
+                  market={ selectedMarketBaseAsset }<br/>
                   account={ account }<br/>
                 </label>
               </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,10 +348,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@compound-finance/comet-extension@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@compound-finance/comet-extension/-/comet-extension-0.0.5.tgz#6d752af83260dec0d12a9b4c2987e93ae833e3a9"
-  integrity sha512-2L7vAsHYstl+Qn8zzzTkYFOocbs+odEKCnSq4zmCuNyKcOrYl9dQ70xnsc5AOGvSTAu9vZv9kdnC6ajO0Bussw==
+"@compound-finance/comet-extension@^0.0.15":
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/@compound-finance/comet-extension/-/comet-extension-0.0.15.tgz#0f7788498e1affcacb3fd4ff6255a7894fc67ecc"
+  integrity sha512-gz4Xwik8vISmopPBchiFRBHm4yuoVxdBhpapuQwP17NvtaIhOmgkmqyRiApbPHXnvqXk4yUdoBLNYfvwFb8F5Q==
   dependencies:
     "@ethersproject/abi" "^5.7.0"
     "@ethersproject/providers" "^5.7.1"


### PR DESCRIPTION
This way extensions can know what market the main app is currently on, and handle that for the extension properly (e.g. whether the market is currently set to "ETH" or "USDC")

We need to have a sync call for (requested) 'pull' messages via `rpc.sendRPC` and handle that resolved data.
- This is necessary to make sure we send data _after_ the extension app is loaded.
We also need to have an async listener for (unprompted) 'push' messages, via `rpc.on(...)`.
- This is necessary in case the data from the main app gets updated, or if the user made an RPC request and the data wasn't ready _yet_ (e.g. market data hasn't been loaded), but is ready at a later time.